### PR TITLE
Add library API and integration test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,7 @@ version = "0.1.0"
 dependencies = [
  "rayon",
  "rusqlite",
+ "tempfile",
 ]
 
 [[package]]
@@ -75,6 +76,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "errno"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +96,24 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi",
+]
 
 [[package]]
 name = "hashbrown"
@@ -105,6 +134,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libc"
+version = "0.2.172"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,6 +149,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "once_cell"
@@ -144,6 +185,12 @@ checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rayon"
@@ -180,6 +227,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,6 +263,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,6 +292,97 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2021"
 [dependencies]
 rusqlite = { version = "0.31", features = ["bundled"] }
 rayon = "1.8"
+
+[dev-dependencies]
+tempfile = "3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,143 @@
+use rayon::prelude::*;
+use rusqlite::{Connection, Result};
+use std::collections::HashSet;
+use std::fs::File;
+use std::io::Write;
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub const CHUNK_SIZE: usize = 50000; // Processa 50k endereços por vez
+pub const MAX_THREADS: usize = 4; // Limita threads simultâneas
+
+pub fn load_wallets(wallets_db: &str) -> Result<HashSet<String>> {
+    let conn = Connection::open(wallets_db)?;
+    conn.execute_batch(
+        "PRAGMA journal_mode=WAL;
+         PRAGMA synchronous=OFF;
+         PRAGMA temp_store=MEMORY;
+         PRAGMA cache_size=-100000;",
+    )?;
+
+    let mut stmt = conn.prepare("SELECT address FROM wallets")?;
+    let mut rows = stmt.query([])?;
+
+    let mut wallets = HashSet::new();
+    while let Some(row) = rows.next()? {
+        wallets.insert(row.get::<_, String>(0)?);
+    }
+
+    Ok(wallets)
+}
+
+pub fn process_all_chunks_streaming(wallets: &HashSet<String>, addr_db: &str) -> Result<Vec<String>> {
+    let all_matches = Arc::new(Mutex::new(Vec::new()));
+    let wallets_arc = Arc::new(wallets.clone());
+    let processed_chunks = Arc::new(Mutex::new(0));
+
+    let chunk_tasks: Vec<_> = (0..MAX_THREADS)
+        .map(|thread_id| {
+            let matches_clone = Arc::clone(&all_matches);
+            let wallets_clone = Arc::clone(&wallets_arc);
+            let processed_clone = Arc::clone(&processed_chunks);
+            let addr_db = addr_db.to_string();
+
+            std::thread::spawn(move || {
+                let mut chunk_idx = thread_id;
+
+                loop {
+                    match process_single_chunk(chunk_idx, &wallets_clone, &addr_db) {
+                        Ok(chunk_matches) => {
+                            if chunk_matches.is_empty() {
+                                break;
+                            }
+
+                            let mut global_matches = matches_clone.lock().unwrap();
+                            global_matches.extend(chunk_matches.clone());
+                            let total_matches = global_matches.len();
+                            drop(global_matches);
+
+                            let mut processed = processed_clone.lock().unwrap();
+                            *processed += 1;
+                            println!(
+                                "✅ Chunk {} processado - {} matches, {} total",
+                                chunk_idx,
+                                chunk_matches.len(),
+                                total_matches
+                            );
+                            drop(processed);
+
+                            chunk_idx += MAX_THREADS;
+                        }
+                        Err(e) => {
+                            eprintln!("⚠️  Erro no chunk {}: {}", chunk_idx, e);
+                            break;
+                        }
+                    }
+                }
+            })
+        })
+        .collect();
+
+    for handle in chunk_tasks {
+        if let Err(e) = handle.join() {
+            eprintln!("⚠️  Thread falhou: {:?}", e);
+        }
+    }
+
+    let final_matches = all_matches.lock().unwrap().clone();
+    Ok(final_matches)
+}
+
+pub fn process_single_chunk(chunk_idx: usize, wallets: &HashSet<String>, addr_db: &str) -> Result<Vec<String>> {
+    let conn = Connection::open(addr_db)?;
+    conn.execute_batch(
+        "PRAGMA journal_mode=WAL;
+         PRAGMA synchronous=OFF;
+         PRAGMA temp_store=MEMORY;
+         PRAGMA cache_size=-25000;",
+    )?;
+
+    let offset = chunk_idx * CHUNK_SIZE;
+    let mut stmt = conn.prepare(&format!(
+        "SELECT address FROM addresses LIMIT {} OFFSET {}",
+        CHUNK_SIZE, offset
+    ))?;
+
+    let mut rows = stmt.query([])?;
+    let mut chunk_addresses = Vec::new();
+
+    while let Some(row) = rows.next()? {
+        chunk_addresses.push(row.get::<_, String>(0)?);
+    }
+
+    if chunk_addresses.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let matches: Vec<String> = chunk_addresses
+        .par_iter()
+        .filter(|addr| wallets.contains(*addr))
+        .cloned()
+        .collect();
+
+    Ok(matches)
+}
+
+pub fn save_to_file(addrs: &[String]) -> std::io::Result<()> {
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?
+        .as_secs();
+
+    let mut f = File::create(format!("coincidencias_{ts}.txt"))?;
+    writeln!(f, "ENDEREÇOS ETHEREUM COINCIDENTES")?;
+    writeln!(f, "Total: {}\n", addrs.len())?;
+
+    for (i, addr) in addrs.iter().enumerate() {
+        writeln!(f, "{}. {}", i + 1, addr)?;
+    }
+
+    println!("💾 Resultado salvo em coincidencias_{ts}.txt");
+    Ok(())
+}
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,9 @@
-use rayon::prelude::*;
-use rusqlite::{Connection, Result};
-use std::collections::HashSet;
-use std::fs::File;
-use std::io::Write;
-use std::sync::{Arc, Mutex};
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use comparer_rust::{load_wallets, process_all_chunks_streaming, save_to_file};
+use rusqlite::Result;
+use std::time::Instant;
 
 const WALLETS_DB: &str = "E:\\rust\\address_checker\\wallets3.db";
 const ADDR_DB: &str = "E:\\rust\\get_addresses\\ethereum_addresses.db";
-const CHUNK_SIZE: usize = 50000; // Processa 50k endereços por vez
-const MAX_THREADS: usize = 4; // Limita threads simultâneas
 
 fn main() -> Result<()> {
     let t0 = Instant::now();
@@ -17,11 +11,11 @@ fn main() -> Result<()> {
     println!("🚀 Iniciando verificação paralela de endereços...");
 
     // 1. Carrega apenas as wallets (dataset menor)
-    let wallets = load_wallets()?;
+    let wallets = load_wallets(WALLETS_DB)?;
     println!("📊 Wallets carregadas: {} endereços", wallets.len());
 
     // 2. Processa em chunks sem saber o total
-    let matches = process_all_chunks_streaming(&wallets)?;
+    let matches = process_all_chunks_streaming(&wallets, ADDR_DB)?;
 
     // 3. Relatório
     let dt = t0.elapsed().as_secs_f64();
@@ -36,143 +30,5 @@ fn main() -> Result<()> {
         println!("ℹ️  Nenhuma coincidência encontrada");
     }
 
-    Ok(())
-}
-
-fn load_wallets() -> Result<HashSet<String>> {
-    let conn = Connection::open(WALLETS_DB)?;
-    conn.execute_batch(
-        "PRAGMA journal_mode=WAL; 
-         PRAGMA synchronous=OFF; 
-         PRAGMA temp_store=MEMORY; 
-         PRAGMA cache_size=-100000;",
-    )?;
-
-    let mut stmt = conn.prepare("SELECT address FROM wallets")?;
-    let mut rows = stmt.query([])?;
-
-    let mut wallets = HashSet::new();
-    while let Some(row) = rows.next()? {
-        wallets.insert(row.get::<_, String>(0)?);
-    }
-
-    Ok(wallets)
-}
-
-fn process_all_chunks_streaming(wallets: &HashSet<String>) -> Result<Vec<String>> {
-    let all_matches = Arc::new(Mutex::new(Vec::new()));
-    let wallets_arc = Arc::new(wallets.clone());
-    let processed_chunks = Arc::new(Mutex::new(0));
-
-    // Processa chunks infinitamente até não haver mais dados
-    let chunk_tasks: Vec<_> = (0..MAX_THREADS)
-        .map(|thread_id| {
-            let matches_clone = Arc::clone(&all_matches);
-            let wallets_clone = Arc::clone(&wallets_arc);
-            let processed_clone = Arc::clone(&processed_chunks);
-
-            std::thread::spawn(move || {
-                let mut chunk_idx = thread_id;
-
-                loop {
-                    match process_single_chunk(chunk_idx, &wallets_clone) {
-                        Ok(chunk_matches) => {
-                            if chunk_matches.is_empty() {
-                                break; // Fim dos dados
-                            }
-
-                            let mut global_matches = matches_clone.lock().unwrap();
-                            global_matches.extend(chunk_matches.clone());
-                            let total_matches = global_matches.len();
-                            drop(global_matches);
-
-                            let mut processed = processed_clone.lock().unwrap();
-                            *processed += 1;
-                            println!(
-                                "✅ Chunk {} processado - {} matches, {} total",
-                                chunk_idx,
-                                chunk_matches.len(),
-                                total_matches
-                            );
-                            drop(processed);
-
-                            chunk_idx += MAX_THREADS;
-                        }
-                        Err(e) => {
-                            eprintln!("⚠️  Erro no chunk {}: {}", chunk_idx, e);
-                            break;
-                        }
-                    }
-                }
-            })
-        })
-        .collect();
-
-    // Espera todas as threads terminarem
-    for handle in chunk_tasks {
-        if let Err(e) = handle.join() {
-            eprintln!("⚠️  Thread falhou: {:?}", e);
-        }
-    }
-
-    // Retorna resultado final
-    let final_matches = all_matches.lock().unwrap().clone();
-    Ok(final_matches)
-}
-
-fn process_single_chunk(chunk_idx: usize, wallets: &HashSet<String>) -> Result<Vec<String>> {
-    let conn = Connection::open(ADDR_DB)?;
-    conn.execute_batch(
-        "PRAGMA journal_mode=WAL; 
-         PRAGMA synchronous=OFF; 
-         PRAGMA temp_store=MEMORY; 
-         PRAGMA cache_size=-25000;",
-    )?;
-
-    let offset = chunk_idx * CHUNK_SIZE;
-    let mut stmt = conn.prepare(&format!(
-        "SELECT address FROM addresses LIMIT {} OFFSET {}",
-        CHUNK_SIZE, offset
-    ))?;
-
-    let mut rows = stmt.query([])?;
-    let mut chunk_addresses = Vec::new();
-
-    // Carrega apenas um chunk pequeno na memória
-    while let Some(row) = rows.next()? {
-        chunk_addresses.push(row.get::<_, String>(0)?);
-    }
-
-    // Se chunk está vazio, retorna vazio
-    if chunk_addresses.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    // Processa chunk em paralelo
-    let matches: Vec<String> = chunk_addresses
-        .par_iter()
-        .filter(|addr| wallets.contains(*addr))
-        .cloned()
-        .collect();
-
-    Ok(matches)
-}
-
-use std::io;
-fn save_to_file(addrs: &[String]) -> io::Result<()> {
-    let ts = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?
-        .as_secs();
-
-    let mut f = File::create(format!("coincidencias_{ts}.txt"))?;
-    writeln!(f, "ENDEREÇOS ETHEREUM COINCIDENTES")?;
-    writeln!(f, "Total: {}\n", addrs.len())?;
-
-    for (i, addr) in addrs.iter().enumerate() {
-        writeln!(f, "{}. {}", i + 1, addr)?;
-    }
-
-    println!("💾 Resultado salvo em coincidencias_{ts}.txt");
     Ok(())
 }

--- a/tests/process_single_chunk.rs
+++ b/tests/process_single_chunk.rs
@@ -1,0 +1,36 @@
+use comparer_rust::{load_wallets, process_single_chunk};
+use rusqlite::Connection;
+use tempfile::NamedTempFile;
+
+#[test]
+fn test_process_single_chunk_matches() -> rusqlite::Result<()> {
+    // wallets db
+    let wallets_temp = NamedTempFile::new().unwrap();
+    let wallets_path = wallets_temp.path();
+    let conn = Connection::open(wallets_path)?;
+    conn.execute_batch("CREATE TABLE wallets (address TEXT);")?;
+    conn.execute("INSERT INTO wallets (address) VALUES (?1)", ["0xabc"])?;
+    conn.execute("INSERT INTO wallets (address) VALUES (?1)", ["0xdef"])?;
+
+    drop(conn);
+
+    // addresses db
+    let addr_temp = NamedTempFile::new().unwrap();
+    let addr_path = addr_temp.path();
+    let conn2 = Connection::open(addr_path)?;
+    conn2.execute_batch("CREATE TABLE addresses (address TEXT);")?;
+    conn2.execute("INSERT INTO addresses (address) VALUES (?1)", ["0x000"])?;
+    conn2.execute("INSERT INTO addresses (address) VALUES (?1)", ["0xabc"])?;
+    conn2.execute("INSERT INTO addresses (address) VALUES (?1)", ["0xdef"])?;
+
+    drop(conn2);
+
+    // load wallets
+    let wallets = load_wallets(wallets_path.to_str().unwrap())?;
+    let mut matches = process_single_chunk(0, &wallets, addr_path.to_str().unwrap())?;
+    matches.sort();
+
+    assert_eq!(matches, vec!["0xabc".to_string(), "0xdef".to_string()]);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- refactor existing code into a library module
- expose helper functions to allow passing database paths
- update binary to use the library API
- add `tempfile` dev-dependency
- create integration test that creates temporary SQLite databases and checks `process_single_chunk`

## Testing
- `cargo test -q`

------
https://chatgpt.com/codex/tasks/task_e_68406aed67f0832eb37bb25debd6f55c