### PR TITLE
Remove unnecessary clone

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -98,7 +98,8 @@ fn process_all_chunks_streaming(wallets: Arc<HashSet<String>>) -> Result<Vec<Str
                             }
 
                             let mut global_matches = matches_clone.lock().unwrap();
-                            global_matches.extend(chunk_matches.clone());
+                            let chunk_len = chunk_matches.len();
+                            global_matches.extend(chunk_matches);
                             let total_matches = global_matches.len();
                             drop(global_matches);
 
@@ -107,7 +108,7 @@ fn process_all_chunks_streaming(wallets: Arc<HashSet<String>>) -> Result<Vec<Str
                             println!(
                                 "✅ Rowid {} processado - {} matches, {} total",
                                 last_rowid,
-                                chunk_matches.len(),
+                                chunk_len,
                                 total_matches
                             );
                             drop(processed);


### PR DESCRIPTION
## Summary
- drop unused clone when extending match results

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684073bd93ac832e82555d9c6c37d718