### PR TITLE
Switch to sequential rowid chunking

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Ferramenta em Rust para verificar endereços de Ethereum em duas bases de dados SQLite.
 
+A partir da versão atual, a leitura da tabela `addresses` utiliza o campo
+`rowid` para percorrer os registros em blocos, evitando o custo de consultas com
+`OFFSET`.
+
 ## Uso
 
 Os caminhos padrões para os bancos são utilizados caso nenhuma opção seja informada. Eles são:

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use rusqlite::{Connection, Result};
 use std::collections::HashSet;
 use std::fs::File;
 use std::io::Write;
-use std::sync::{Arc, Mutex};
+
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 fn verify_table_exists(conn: &Connection, table: &str, db_path: &str) -> Result<()> {
@@ -26,7 +26,6 @@ fn verify_addresses_table(path: &str) -> Result<()> {
 const DEFAULT_WALLETS_DB: &str = "E:\\rust\\address_checker\\wallets3.db";
 const DEFAULT_ADDR_DB: &str = "E:\\rust\\get_addresses\\ethereum_addresses.db";
 const CHUNK_SIZE: usize = 50000; // Processa 50k endereços por vez
-const MAX_THREADS: usize = 4; // Limita threads simultâneas
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -95,72 +94,6 @@ fn load_wallets(path: &str) -> Result<HashSet<String>> {
 }
 
 fn process_all_chunks_streaming(wallets: &HashSet<String>, addr_db: &str) -> Result<Vec<String>> {
-    let all_matches = Arc::new(Mutex::new(Vec::new()));
-    let wallets_arc = Arc::new(wallets.clone());
-    let addr_db_arc = Arc::new(addr_db.to_string());
-    let processed_chunks = Arc::new(Mutex::new(0));
-
-    // Processa chunks infinitamente até não haver mais dados
-    let chunk_tasks: Vec<_> = (0..MAX_THREADS)
-        .map(|thread_id| {
-            let matches_clone = Arc::clone(&all_matches);
-            let wallets_clone = Arc::clone(&wallets_arc);
-            let processed_clone = Arc::clone(&processed_chunks);
-            let db_clone = Arc::clone(&addr_db_arc);
-
-            std::thread::spawn(move || {
-                let mut chunk_idx = thread_id;
-
-                loop {
-                    match process_single_chunk(chunk_idx, &wallets_clone, db_clone.as_str()) {
-                        Ok(Some(chunk_matches)) => {
-                            let mut global_matches = matches_clone.lock().unwrap();
-                            global_matches.extend(chunk_matches.clone());
-                            let total_matches = global_matches.len();
-                            drop(global_matches);
-
-                            let mut processed = processed_clone.lock().unwrap();
-                            *processed += 1;
-                            println!(
-                                "✅ Chunk {} processado - {} matches, {} total",
-                                chunk_idx,
-                                chunk_matches.len(),
-                                total_matches
-                            );
-                            drop(processed);
-
-                            chunk_idx += MAX_THREADS;
-                        }
-                        Ok(None) => {
-                            break; // Fim dos dados
-                        }
-                        Err(e) => {
-                            eprintln!("⚠️  Erro no chunk {}: {}", chunk_idx, e);
-                            break;
-                        }
-                    }
-                }
-            })
-        })
-        .collect();
-
-    // Espera todas as threads terminarem
-    for handle in chunk_tasks {
-        if let Err(e) = handle.join() {
-            eprintln!("⚠️  Thread falhou: {:?}", e);
-        }
-    }
-
-    // Retorna resultado final
-    let final_matches = all_matches.lock().unwrap().clone();
-    Ok(final_matches)
-}
-
-fn process_single_chunk(
-    chunk_idx: usize,
-    wallets: &HashSet<String>,
-    addr_db: &str,
-) -> Result<Option<Vec<String>>> {
     let conn = Connection::open(addr_db)?;
     conn.execute_batch(
         "PRAGMA journal_mode=WAL;
@@ -169,33 +102,35 @@ fn process_single_chunk(
          PRAGMA cache_size=-25000;",
     )?;
 
-    let offset = chunk_idx * CHUNK_SIZE;
-    let mut stmt = conn.prepare(&format!(
-        "SELECT address FROM addresses LIMIT {} OFFSET {}",
-        CHUNK_SIZE, offset
-    ))?;
+    let mut all_matches = Vec::new();
+    let mut last_rowid: i64 = 0;
 
-    let mut rows = stmt.query([])?;
-    let mut chunk_addresses = Vec::new();
+    loop {
+        let mut stmt = conn.prepare(
+            "SELECT rowid, address FROM addresses WHERE rowid > ? ORDER BY rowid LIMIT ?",
+        )?;
+        let mut rows = stmt.query(rusqlite::params![last_rowid, CHUNK_SIZE as i64])?;
 
-    // Carrega apenas um chunk pequeno na memória
-    while let Some(row) = rows.next()? {
-        chunk_addresses.push(row.get::<_, String>(0)?);
+        let mut chunk_addresses = Vec::new();
+        while let Some(row) = rows.next()? {
+            last_rowid = row.get::<_, i64>(0)?;
+            chunk_addresses.push(row.get::<_, String>(1)?);
+        }
+
+        if chunk_addresses.is_empty() {
+            break;
+        }
+
+        let matches: Vec<String> = chunk_addresses
+            .par_iter()
+            .filter(|addr| wallets.contains(&addr.to_lowercase()))
+            .cloned()
+            .collect();
+
+        all_matches.extend(matches);
     }
 
-    // Se chunk está vazio, não há mais linhas
-    if chunk_addresses.is_empty() {
-        return Ok(None);
-    }
-
-    // Processa chunk em paralelo com comparação case-insensitive
-    let matches: Vec<String> = chunk_addresses
-        .par_iter()
-        .filter(|addr| wallets.contains(&addr.to_lowercase()))
-        .cloned()
-        .collect();
-
-    Ok(Some(matches))
+    Ok(all_matches)
 }
 
 use std::io;


### PR DESCRIPTION
## Summary
- avoid costly OFFSET queries by iterating using `rowid`
- simplify chunk processing logic
- document new `rowid` scanning approach in README

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6840d863ba9c832ea8b143efd67fcfee