### PR TITLE
Enhance DB scan with parallel ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 Ferramenta em Rust para verificar endereços de Ethereum em duas bases de dados SQLite.
 
-A partir da versão atual, a leitura da tabela `addresses` utiliza o campo
-`rowid` para percorrer os registros em blocos, evitando o custo de consultas com
-`OFFSET`.
+A partir da versão atual, a leitura da tabela `addresses` é dividida em faixas
+de `rowid` processadas em paralelo, cada qual abrindo sua própria conexão
+SQLite. Isso evita o custo de consultas com `OFFSET` e aproveita melhor as
+várias CPUs disponíveis.
 
 ## Uso
 


### PR DESCRIPTION
## Summary
- parallelize DB scanning with `process_all_chunks_parallel`
- update call site and docs
- resolve Clippy lint when saving results

## Testing
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6840f141df7c832eb803cb2b2eb74129